### PR TITLE
Add profile pic links to the header.

### DIFF
--- a/tutoringApp/profiles/context_processors.py
+++ b/tutoringApp/profiles/context_processors.py
@@ -1,0 +1,20 @@
+"""Custom context processors for profile app."""
+from django.http import HttpRequest
+
+
+def add_profile_pic_url_processor(request: HttpRequest) -> dict[str, str]:
+    """Add current user's profile picture URL to context.
+
+    The method checks if the info about current user's profile
+    picture is present in the session info and if so, it gets
+    added to the context.
+
+    Args:
+        request: An instance of the HttpRequest, containing
+                    information about the request sent by the user.
+    """
+    return (
+        {"profile_pic_url": request.session.get("profile_pic_url")}
+        if request.session.get("profile_pic_url")
+        else {}
+    )

--- a/tutoringApp/templates/tutoringApp/base.html
+++ b/tutoringApp/templates/tutoringApp/base.html
@@ -39,7 +39,7 @@
                         </a>
                     </div>
                     <div class="header-right-profile">
-                        <img src="{% static 'default_profile_pic.jpg' %}">
+                        <img src="{{profile_pic_url}}">
                     </div>
                     <label for="header-right-checkbox">
                         <div class="header-right-arrow icon_green">

--- a/tutoringApp/tutoringApp/settings.py
+++ b/tutoringApp/tutoringApp/settings.py
@@ -67,6 +67,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "profiles.context_processors.add_profile_pic_url_processor"
             ],
         },
     },


### PR DESCRIPTION
# What 

Mechanism for displaying the current user's profile picture in the header. The mechanism takes advantage of the `session` object and introduces a context processor. 

The info about the the profile picture URL gets fetched only once when the user logs in and gets added to the session object. From that point on, whenever a request is made to any of the pages, the `add_profile_pic_url_processor` context processor fetches the URL from the session and adds it to the current template's context. When the user logs out, the URL is deleted from the `session` object. 